### PR TITLE
Add rake and bundler tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+require 'bundler/gem_tasks'

--- a/frontapp.gemspec
+++ b/frontapp.gemspec
@@ -14,4 +14,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'http', '>= 2.2.1'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'webmock'
+  s.add_development_dependency 'rake', '~> 12.0'
 end


### PR DESCRIPTION
I noticed this library hadn't been pushed to RubyGems quite yet, [so I took the liberty](https://rubygems.org/gems/frontapp) since I needed it for a project I'm working on.

This PR adds `rake` as a dependency, along with the necessary tasks to publish the gem. Let me know if you'd like me to transfer ownership of the gem over to you.

Thanks for the great lib!