### PR TITLE
Add Support for Custom Fields when Creating and Updating a Contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,26 +81,26 @@ contact = client.get_contact("ctc_55c8c149")
 
 # Update a contact
 client.update_contact!("ctc_55c8c149", {
-	name: "Name",
-	description: "Description",
-	avatar_url: "http://example.com/avatar",
-	is_spammer: false,
-	links: ["http://example.com"],
-	group_names: ["Customer"]
+  name: "Name",
+  description: "Description",
+  avatar_url: "http://example.com/avatar",
+  is_spammer: false,
+  links: ["http://example.com"],
+  group_names: ["Customer"]
 })
 
 # Create a new contact
 contact = client.create_contact!({
-	name: "Name",
-	description: "Description",
-	avatar_url: "http://example.com/avatar",
-	is_spammer: false,
-	links: ["http://example.com"],
-	group_names: ["Customer"]
-	handles: [{
-      "handle": "@calculon",
-      "source": "twitter"
-    }]
+  name: "Name",
+  description: "Description",
+  avatar_url: "http://example.com/avatar",
+  is_spammer: false,
+  links: ["http://example.com"],
+  group_names: ["Customer"],
+  handles: [{
+    "handle": "@calculon",
+    "source": "twitter"
+  }]
 })
 
 # Delete a contact

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ contact = client.create_contact!({
   handles: [{
     "handle": "@calculon",
     "source": "twitter"
-  }]
+  }],
+  custom_fields: {
+    job_title: "Engineer"
+  }
 })
 
 # Delete a contact

--- a/lib/frontapp/client/contacts.rb
+++ b/lib/frontapp/client/contacts.rb
@@ -24,12 +24,13 @@ module Frontapp
       # Allowed attributes:
       # Name         Type                Description
       # --------------------------------------------
-      # name         string (optional)   Contact name
-      # description  string (optional)   Contact description
-      # avatar_url   string (optional)   URL of the contact’s avatar
-      # is_spammer   boolean (optional)  Whether or not the contact is marked as a spammer
-      # links        array (optional)    List of all the links of the contact
-      # group_names  array (optional)    List of all the group names the contact belongs to. It will automatically create missing groups.
+      # name          string (optional)   Contact name
+      # description   string (optional)   Contact description
+      # avatar_url    string (optional)   URL of the contact’s avatar
+      # is_spammer    boolean (optional)  Whether or not the contact is marked as a spammer
+      # links         array (optional)    List of all the links of the contact
+      # group_names   array (optional)    List of all the group names the contact belongs to. It will automatically create missing groups.
+      # custom_fields object (optional)   Custom field attributes for this contact. Leave empty if you do not wish to update the attributes. Not sending existing attributes will automatically remove them.
       # --------------------------------------------
       def update_contact!(contact_id, params = {})
         cleaned = params.permit(:name,
@@ -37,7 +38,8 @@ module Frontapp
                                 :avatar_url,
                                 :is_spammer,
                                 :links,
-                                :group_names)
+                                :group_names,
+                                :custom_fields)
         update("contacts/#{contact_id}", cleaned)
       end
 
@@ -50,7 +52,8 @@ module Frontapp
       # is_spammer   boolean (optional)  Whether or not the contact is marked as a spammer
       # links        array (optional)    List of all the links of the contact
       # group_names  array (optional)    List of all the group names the contact belongs to. It will automatically create missing groups.
-      # handles      array               List
+      # handles      array               List of the contact handles
+      # custom_fields object (optional)  Custom field attributes for this contact. Leave empty if you do not wish to update the attributes. Not sending existing attributes will automatically remove them.
       # --------------------------------------------
       def create_contact!(params = {})
         cleaned = params.permit(:name,
@@ -59,7 +62,8 @@ module Frontapp
                                 :is_spammer,
                                 :links,
                                 :group_names,
-                                :handles)
+                                :handles,
+                                :custom_fields)
         create("contacts", cleaned)
       end
 

--- a/spec/contacts_spec.rb
+++ b/spec/contacts_spec.rb
@@ -132,7 +132,10 @@ RSpec.describe 'Contacts' do
       "id": "grp_55c8c149",
       "name": "Customers"
     }
-  ]
+  ],
+  "custom_fields": {
+    "job title": "engineer"
+  }
 }
     }
   }
@@ -336,7 +339,10 @@ RSpec.describe 'Contacts' do
       links: [
         "http://example.com"
       ],
-      group_names: [ "Customers" ]
+      group_names: [ "Customers" ],
+      custom_fields: {
+        "job title": "engineer"
+      }
     }
     stub_request(:patch, "#{base_url}/contacts/#{contact_id}").
       with( body: data.to_json,
@@ -360,7 +366,10 @@ RSpec.describe 'Contacts' do
           handle: "@calculon",
           source: "twitter"
         }
-      ]
+      ],
+      custom_fields: {
+        "job title": "engineer"
+      }
     }
     stub_request(:post, "#{base_url}/contacts").
       with( body: data.to_json,


### PR DESCRIPTION
Hello,

Thanks a tonne for making this library available, it's helped to make a speedy integration with Front. 

We're wanting to include [custom fields](https://dev.frontapp.com/#custom-fields) when we sync contacts between our app and Front. This patch adds support for custom fields when creating and updating a contact.

I'd love to get this merged into master. I'm very open to any feedback you have.

Cheers,
Tate