### PR TITLE
Fix ordering when stubbing request body in specs

### DIFF
--- a/spec/messages_spec.rb
+++ b/spec/messages_spec.rb
@@ -106,8 +106,8 @@ RSpec.describe 'Messages' do
   it "can send a message from a channel" do
     data = {
       author_id: "alt:email:leela@planet-exress.com",
-      subject: "Good news everyone!",
       sender_name: 'Leela',
+      subject: "Good news everyone!",
       body: "Why is Zoidberg the only one still alone?",
       text: "Why is Zoidberg the only one still alone?",
       options: {
@@ -128,8 +128,8 @@ RSpec.describe 'Messages' do
   it "can send a reply" do
     data = {
       author_id: "alt:email:leela@planet-exress.com",
-      subject: "Good news everyone!",
       sender_name: 'Leela',
+      subject: "Good news everyone!",
       body: "Why is Zoidberg the only one still alone?",
       text: "Why is Zoidberg the only one still alone?",
       options: {


### PR DESCRIPTION
I was preparing a couple of patches and noticed the tests on master were failing. It looks like Webmock expects the data in the request to be ordered the same as the stub, even though order shouldn't matter for a hash/JSON object. This patch makes the tests ✅ 