### PR TITLE
Add custom error subclasses so that they can be distinguished from other errors

### DIFF
--- a/frontapp.gemspec
+++ b/frontapp.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby client for Frontapp API"
   s.authors     = ["Niels van der Zanden"]
   s.email       = 'niels@phusion.nl'
-  s.files       = ["lib/frontapp.rb", "lib/frontapp/client.rb"]
+  s.files       = ["lib/frontapp.rb", "lib/frontapp/client.rb", "lib/frontapp/error.rb"]
   s.files       += Dir.glob("lib/frontapp/client/*.rb")
   s.files       += Dir.glob("lib/frontapp/utils/*.rb")
   s.homepage    = 'https://github.com/phusion/frontapp'

--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -15,6 +15,7 @@ require_relative 'client/teammates.rb'
 require_relative 'client/teams.rb'
 require_relative 'client/topics.rb'
 require_relative 'client/exports.rb'
+require_relative 'error'
 
 module Frontapp
   class Client
@@ -63,6 +64,9 @@ module Frontapp
 
     def get(path)
       res = @headers.get("#{base_url}#{path}")
+      if !res.status.success?
+        raise Error.from_response(res)
+      end
       JSON.parse(res.to_s)
     end
 
@@ -70,7 +74,7 @@ module Frontapp
       res = @headers.post("#{base_url}#{path}", json: body)
       response = JSON.parse(res.to_s)
       if !res.status.success?
-        raise "Response: #{res.inspect}\n Body: #{res.body}\nRequest: #{body.to_json.inspect}"
+        raise Error.from_response(res)
       end
       response
     end
@@ -78,21 +82,21 @@ module Frontapp
     def create_without_response(path, body)
       res = @headers.post("#{base_url}#{path}", json: body)
       if !res.status.success?
-        raise "Response: #{res.inspect}\n Body: #{res.body}\nRequest: #{body.to_json.inspect}"
+        raise Error.from_response(res)
       end
     end
 
     def update(path, body)
       res = @headers.patch("#{base_url}#{path}", json: body)
       if !res.status.success?
-        raise "Response: #{res.inspect}\n Body: #{res.body}\nRequest: #{body.to_json.inspect}"
+        raise Error.from_response(res)
       end
     end
 
     def delete(path, body = {})
       res = @headers.delete("#{base_url}#{path}", json: body)
       if !res.status.success?
-        raise "Response: #{res.inspect}\n Body: #{res.body}\nRequest: #{body.to_json.inspect}"
+        raise Error.from_response(res)
       end
     end
 

--- a/lib/frontapp/error.rb
+++ b/lib/frontapp/error.rb
@@ -1,0 +1,22 @@
+module Frontapp
+  class Error < StandardError
+    def self.from_response(response)
+      error_class = case response.status
+        when 400 then BadRequestError
+        when 404 then NotFoundError
+        when 409 then ConflictError
+        else self.class
+        end
+      error_class.new(response)
+    end
+
+    def initialize(response)
+      @response = response
+      super("Response: #{response.inspect}\nBody: #{response.body}")
+    end
+  end
+
+  class BadRequestError < Error; end
+  class NotFoundError < Error; end
+  class ConflictError < Error; end
+end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,42 @@
+require "spec_helper"
+require "frontapp"
+
+RSpec.describe "Errors" do
+  let(:headers) {
+    {
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{auth_token}",
+    }
+  }
+  let(:frontapp) { Frontapp::Client.new(auth_token: auth_token) }
+
+  it "can raise a bad request error" do
+    stub_request(:get, "#{base_url}/contacts/1").
+      with(headers: headers).
+      to_return(status: 400, body: "{}")
+
+    expect do
+      frontapp.get_contact(1)
+    end.to raise_error(Frontapp::BadRequestError)
+  end
+
+  it "can raise a not found error" do
+    stub_request(:get, "#{base_url}/contacts/1").
+      with(headers: headers).
+      to_return(status: 404, body: "{}")
+
+    expect do
+      frontapp.get_contact(1)
+    end.to raise_error(Frontapp::NotFoundError)
+  end
+
+  it "can raise a conflict error" do
+    stub_request(:get, "#{base_url}/contacts/1").
+      with(headers: headers).
+      to_return(status: 409, body: "{}")
+
+    expect do
+      frontapp.get_contact(1)
+    end.to raise_error(Frontapp::ConflictError)
+  end
+end


### PR DESCRIPTION
This patch makes it so that failed HTTP requests are raised as `Frontapp::Error` or one of its descendants. It's based on the pattern I first saw in the [Octokit gem](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/error.rb).

This is useful if you need handle errors differently or if you want to silence specific errors in your exception tracker. I've only implemented a handful of the errors that we need to handle in our app, but would be happy to extend this further if you want.

As always, I'm very welcome to any feedback you have.