### PR TITLE
Add support for custom user agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ require 'frontapp'
 client = Frontapp::Client.new(auth_token: 'token') 
 ```
 
+Optionally, set a custom user agent to identify your integration
+```ruby
+client = Frontapp::Client.new(auth_token: 'token', user_agent: 'Eye-Phone Integration (engineering@planet-express.com')
+```
+
 ### Channels
 ```ruby
 # Get all channels

--- a/frontapp.gemspec
+++ b/frontapp.gemspec
@@ -1,12 +1,16 @@
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "frontapp/version"
+
 Gem::Specification.new do |s|
   s.name        = 'frontapp'
-  s.version     = '0.0.4'
+  s.version     = Frontapp::VERSION
   s.date        = '2018-10-15'
   s.summary     = "Ruby client for Frontapp API"
   s.description = "Ruby client for Frontapp API"
   s.authors     = ["Niels van der Zanden"]
   s.email       = 'niels@phusion.nl'
-  s.files       = ["lib/frontapp.rb", "lib/frontapp/client.rb", "lib/frontapp/error.rb"]
+  s.files       = ["lib/frontapp.rb", "lib/frontapp/client.rb", "lib/frontapp/error.rb", "lib/frontapp/version.rb"]
   s.files       += Dir.glob("lib/frontapp/client/*.rb")
   s.files       += Dir.glob("lib/frontapp/utils/*.rb")
   s.homepage    = 'https://github.com/phusion/frontapp'

--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -16,6 +16,7 @@ require_relative 'client/teams.rb'
 require_relative 'client/topics.rb'
 require_relative 'client/exports.rb'
 require_relative 'error'
+require_relative 'version'
 
 module Frontapp
   class Client
@@ -37,9 +38,11 @@ module Frontapp
 
     def initialize(options={})
       auth_token = options[:auth_token]
+      user_agent = options[:user_agent] || "Frontapp Ruby Gem #{VERSION}"
       @headers = HTTP.headers({
         Accept: "application/json",
-        Authorization: "Bearer #{auth_token}"
+        Authorization: "Bearer #{auth_token}",
+        "User-Agent": user_agent
       })
     end
 

--- a/lib/frontapp/version.rb
+++ b/lib/frontapp/version.rb
@@ -1,0 +1,3 @@
+module Frontapp
+  VERSION = "0.0.4"
+end

--- a/spec/user_agent_spec.rb
+++ b/spec/user_agent_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'frontapp'
+
+RSpec.describe 'User agent' do
+  let(:headers) {
+    {
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{auth_token}",
+    }
+  }
+  let(:create_tag_data) {
+    {name: "New tag name"}
+  }
+  let(:create_tag_response) {
+    %Q{
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/tags/tag_55c8c149",
+    "related": {
+      "conversations": "https://api2.frontapp.com/tags/tag_55c8c149/conversations"
+    }
+  },
+  "id": "tag_55c8c149",
+  "name": "New tag name"
+}
+    }
+  }
+
+  it "has a default user agent" do
+    stub_request(:post, "#{base_url}/tags").
+      with(
+        body: create_tag_data.to_json,
+        headers: headers.merge("User-Agent": "Frontapp Ruby Gem #{Frontapp::VERSION}")).
+      to_return(status: 201, body: create_tag_response)
+    frontapp = Frontapp::Client.new(auth_token: auth_token)
+    expect do
+      frontapp.create_tag!(create_tag_data)
+    end.to_not raise_error
+  end
+
+  it "can have a custom user agent" do
+    user_agent = "Eye-Phone Integration (engineering@planet-express.com)"
+    stub_request(:post, "#{base_url}/tags").
+      with(
+        body: create_tag_data.to_json,
+        headers: headers.merge("User-Agent": user_agent)).
+      to_return(status: 201, body: create_tag_response)
+    frontapp = Frontapp::Client.new(auth_token: auth_token, user_agent: user_agent)
+    expect do
+      frontapp.create_tag!(create_tag_data)
+    end
+  end
+end


### PR DESCRIPTION
This patch makes it so that integrators can set a custom user agent that identifies their user agent. This makes it easier for Front to reach out to the engineering-team if there's an issue with the integration.

It also defaults the user agent for the gem to "Frontapp Ruby Gem x.x.x". I've introduced a VERSION constant so that we can define it once and reference it many places. Let me know how you feel about that and I can wind it back.

This is the last patch I'd like to make to this already very useful library. Let me know if I can help in any other way.