### PR TITLE
Add method to get message source, bugfixes for query formatting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .rspec
 Gemfile.lock
 vendor
+
+# ignore RVM config
+.versions.conf
+

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ teammates = client.get_inbox_teammates("inb_55c8c149")
 # Get a specific message
 message = client.get_message("msg_55c8c149")
 
+# Get raw email source for a specific message
+message_source = client.get_message_source("msg_55c8c149")
+
 # Send a new message to a channel
 conversation_reference = client.send_message("cha_55c8c149", {
   author_id: "user@example.com",

--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -75,6 +75,15 @@ module Frontapp
       end
       JSON.parse(res.to_s)
     end
+    
+    def get_plain(path)
+      headers_copy = @headers.dup
+      res = @headers.accept("text/plain").get("#{base_url}#{path}")
+      if !res.status.success?
+        raise Error.from_response(res)
+      end
+      res.to_s
+    end
 
     def create(path, body)
       res = @headers.post("#{base_url}#{path}", json: body)
@@ -114,13 +123,15 @@ module Frontapp
         res << q.map do |k, v|
           case v
           when Symbol, String
-            "q[#{k}][]=#{URI.encode(v)}"
+            "q[#{k}]=#{URI.encode(v)}"
           when Array then
-            v.map { |c| "q[#{k}][]=#{URI.encode(c)}" }.join("&")
+            v.map { |c| "q[#{k}][]=#{URI.encode(c.to_s)}" }.join("&")
+          else
+            "q[#{k}]=#{URI.encode(v.to_s)}"
           end
         end
       end
-      res << params.map {|k,v| "#{k}=#{URI.encode(v)}"}
+      res << params.map {|k,v| "#{k}=#{URI.encode(v.to_s)}"}
       res.join("&")
     end
 

--- a/lib/frontapp/client/messages.rb
+++ b/lib/frontapp/client/messages.rb
@@ -10,7 +10,17 @@ module Frontapp
       def get_message(message_id)
         get("messages/#{message_id}")
       end
-
+      
+      # Parameters
+      # Name        Type    Description
+      # -------------------------------
+      # message_id  string  Id of the requested message
+      # -------------------------------
+      def get_message_source(message_id)
+        get_plain("messages/#{message_id}").b
+        # .b sets encoding to ASCII-8BIT, which is safer for raw emails than UTF-8
+      end
+      
       # Parameters
       # Name        Type    Description
       # -------------------------------

--- a/spec/messages_spec.rb
+++ b/spec/messages_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe 'Messages' do
 }
     }
   }
+  let(:message_source) { "Who wants to live forever?" }
   let(:send_message_from_channel_response) {
     %Q{
 {
@@ -102,7 +103,15 @@ RSpec.describe 'Messages' do
       to_return(status: 200, body: get_message_response)
     frontapp.get_message(message_id)
   end
-
+  
+  it "can get a specific message source" do
+    headers['Accept'] = 'text/plain'
+    stub_request(:get, "#{base_url}/messages/#{message_id}").
+      with( headers: headers).
+      to_return(status: 200, body: message_source)
+    frontapp.get_message_source(message_id)
+  end
+  
   it "can send a message from a channel" do
     data = {
       author_id: "alt:email:leela@planet-exress.com",


### PR DESCRIPTION
Added method to get message source using Accept: text/plain. The message is returned in ASCII-8BIT encoding, which is safer for raw email than the default UTF-8.

Fixed bug where String/Symbol 'q' parameters were being encoded as an array.
Query formatter can now accept non-string query values.

**Note**: Changing the String/Symbol query formatting from being encoded as an array will probably break a call where a parameter that should be an array is passed as a string. e.g. 

`conversations = client.get_inbox_conversations("inb_55c8c149", { q: { statuses: ["assigned", "unassigned"] } })
`
will still work, but 

`conversations = client.get_inbox_conversations("inb_55c8c149", { q: { statuses: "assigned" } })
`
probably won't. However, 'q' parameters using non-array values will now work correctly:

`client.events({limit: 100, q: {types: ['tag', 'untag'], after: 1.day.ago.to_i} })
`
