### PR TITLE
Add to list of known Errors

### DIFF
--- a/lib/frontapp/error.rb
+++ b/lib/frontapp/error.rb
@@ -6,6 +6,7 @@ module Frontapp
         when 401 then UnauthorizedError
         when 404 then NotFoundError
         when 409 then ConflictError
+        when 429 then TooManyRequestsError
         else self
         end
       error_class.new(response)
@@ -21,4 +22,5 @@ module Frontapp
   class NotFoundError < Error; end
   class ConflictError < Error; end
   class UnauthorizedError < Error; end
+  class TooManyRequestsError < Error; end
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -39,4 +39,14 @@ RSpec.describe "Errors" do
       frontapp.get_contact(1)
     end.to raise_error(Frontapp::ConflictError)
   end
+
+  it "can raise a too many requests error" do
+    stub_request(:get, "#{base_url}/contacts/1").
+      with(headers: headers).
+      to_return(status: 429, body: "{}")
+
+    expect do
+      frontapp.get_contact(1)
+    end.to raise_error(Frontapp::TooManyRequestsError)
+  end
 end


### PR DESCRIPTION
TooManyRequests is an additional error we have seen returned from Frontapp. Adding this will help us differentiate our response to the error. The original PR for splitting errors is #5.

Please let me know if there are any issues or anything else required.
