### PR TITLE
Add support for downloading attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ The auth_token can be obtained from Frontapp, in Settings -> API & Integrations 
 Create a Frontapp client
 ```ruby
 require 'frontapp'
-client = Frontapp::Client.new(auth_token: 'token') 
+client = Frontapp::Client.new(auth_token: 'token')
 ```
 
 Optionally, set a custom user agent to identify your integration
 ```ruby
 client = Frontapp::Client.new(auth_token: 'token', user_agent: 'Eye-Phone Integration (engineering@planet-express.com')
+```
+
+### Attachments
+```ruby
+# Download a file attachment
+attachment_file = client.download_attachment("fil_55c8c149")
 ```
 
 ### Channels

--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'http'
 require 'json'
+require_relative 'client/attachments.rb'
 require_relative 'client/channels.rb'
 require_relative 'client/comments.rb'
 require_relative 'client/contact_groups.rb'
@@ -21,6 +22,7 @@ require_relative 'version'
 module Frontapp
   class Client
 
+    include Frontapp::Client::Attachments
     include Frontapp::Client::Channels
     include Frontapp::Client::Comments
     include Frontapp::Client::ContactGroups
@@ -75,7 +77,7 @@ module Frontapp
       end
       JSON.parse(res.to_s)
     end
-    
+
     def get_plain(path)
       headers_copy = @headers.dup
       res = @headers.accept("text/plain").get("#{base_url}#{path}")
@@ -83,6 +85,15 @@ module Frontapp
         raise Error.from_response(res)
       end
       res.to_s
+    end
+
+    def get_raw(path)
+      headers_copy = @headers.dup
+      res = @headers.get("#{base_url}#{path}")
+      if !res.status.success?
+        raise Error.from_response(res)
+      end
+      res
     end
 
     def create(path, body)

--- a/lib/frontapp/client/attachments.rb
+++ b/lib/frontapp/client/attachments.rb
@@ -1,0 +1,15 @@
+module Frontapp
+  class Client
+    module Attachments
+
+      # Parameters
+      # Name                Type    Description
+      # ----------------------------------------------------------
+      # attachment_link_id  string  Id of the requested attachment
+      # ----------------------------------------------------------
+      def download_attachment(attachment_link_id)
+        get_raw("download/#{attachment_link_id}")
+      end
+    end
+  end
+end

--- a/spec/attachments_spec.rb
+++ b/spec/attachments_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'frontapp'
+
+RSpec.describe 'Attachments' do
+
+  let(:headers) {
+    {
+      "Accept" => "application/json",
+      "Authorization" => "Bearer #{auth_token}",
+    }
+  }
+  let(:frontapp) { Frontapp::Client.new(auth_token: auth_token) }
+  let(:attachment_link_id) { "fil_55c8c149" }
+  let(:download_attachment_response) {
+    %Q{
+      {
+        "id":"fil_55c8c149",
+        "filename":"some-file.pdf",
+        "url":"https://www.example.com/xyz/some-file.pdf",
+        "content_type":"application/pdf",
+        "size": 325214,
+        "metadata":{
+          "is_inline":true,
+          "cid":"c-xyz-123"
+        }
+      }
+    }
+  }
+
+  it "can get a file attachment details" do
+    stub_request(:get, "#{base_url}/download/#{attachment_link_id}").
+      with( headers: headers).
+      to_return(status: 200, body: File.read("spec/fixtures/sample.txt"))
+    frontapp.download_attachment(attachment_link_id)
+  end
+end

--- a/spec/fixtures/sample.txt
+++ b/spec/fixtures/sample.txt
@@ -1,0 +1,1 @@
+I'm a sample attachment


### PR DESCRIPTION
This small PR adds the ability to download attachments as laid out in the Front API docs here: https://dev.frontapp.com/reference/attachments-1

Usage:

```ruby
file = client.download_attachment(attachment_download_id)
```