### PR TITLE
adds links feature to deprecate topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ events = client.get_conversation_events("cnv_55c8c149")
 # Get all messages for a conversation
 messages = client.get_conversation_messages("cnv_55c8c149")
 
+# Add conversation links (by link_id)
+client.add_conversation_links!("cnv_55c8c149", {
+  link_ids: ["top_3ii5d", "top_3ih5t"]
+})
+
+# Add conversation links (by link) (it creates the link if doesn't exist)
+client.add_conversation_links!("cnv_55c8c149", {
+  link_links: ["https://example.com"]
+})
+
+# Remove conversation links
+client.remove_conversation_links!("cnv_55c8c149", {
+  link_ids: ["top_3ii5d", "top_3ih5t"]
+})
 ```
 
 ### Events
@@ -345,11 +359,33 @@ inboxes = client.get_teammate_inboxes("user@example.com")
 ```
 
 ### Topics
+Topics is deprecated, please use Links instead!
 ```ruby
 # Get all conversations for a topic
 # Optionally include a filter for conversation statuses
 conversations = client.get_topic_conversations("top_55c8c149", { q: { statuses: ["assigned", "unassigned"] } })
 ```
+
+### Links
+```ruby
+# Get all links
+links = client.links
+
+# Get a link
+link = client.get_link("top_55c8c149")
+
+# Create a new link
+link = client.create_link!({
+  name: "Nice link",
+  external_url: "https://www.example.com/nice_link"
+})
+
+# Update a link
+client.update_link!("top_55c8c149", { name: "Something new" })
+
+# Get all conversations for a link
+# Optionally include a filter for conversation statuses
+conversations = client.get_link_conversations("top_55c8c149", { q: { statuses: ["assigned", "unassigned"] } })
 
 ### Exports
 ```ruby

--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -15,6 +15,7 @@ require_relative 'client/tags.rb'
 require_relative 'client/teammates.rb'
 require_relative 'client/teams.rb'
 require_relative 'client/topics.rb'
+require_relative 'client/links.rb'
 require_relative 'client/exports.rb'
 require_relative 'error'
 require_relative 'version'
@@ -36,6 +37,7 @@ module Frontapp
     include Frontapp::Client::Teammates
     include Frontapp::Client::Teams
     include Frontapp::Client::Topics
+    include Frontapp::Client::Links
     include Frontapp::Client::Exports
 
     def initialize(options={})

--- a/lib/frontapp/client/conversations.rb
+++ b/lib/frontapp/client/conversations.rb
@@ -70,6 +70,29 @@ module Frontapp
       def get_conversation_messages(conversation_id)
         list("conversations/#{conversation_id}/messages")
       end
+
+      # Parameters
+      # Name             Type              Description
+      # ----------------------------------------------
+      # conversation_id     string            The conversation Id
+      # link_ids            array (optional)  Link IDs to add Either link_ids or link_external_urls must be specified but not both
+      # link_external_urls  array (optional)  Link external urls to add. Creates links if necessary. Either link_ids or link_external_urls must be specified but not both
+      # ----------------------------------------------
+      def add_conversation_links!(conversation_id, params = {})
+        cleaned = params.permit(:link_ids, :link_external_urls)
+        create_without_response("conversations/#{conversation_id}/links", cleaned)
+      end
+
+      # Parameters
+      # Name             Type              Description
+      # ----------------------------------------------
+      # conversation_id  string            The conversation Id
+      # link_ids        array of strings  link IDs to remove
+      # ----------------------------------------------
+      def remove_conversation_links!(conversation_id, params = {})
+        cleaned = params.permit(:link_ids)
+        delete("conversations/#{conversation_id}/links", cleaned)
+      end
     end
   end
 end

--- a/lib/frontapp/client/links.rb
+++ b/lib/frontapp/client/links.rb
@@ -1,0 +1,64 @@
+module Frontapp
+  class Client
+    module Links
+
+      def links(params = {})
+        cleaned = params.permit({ q: [:statuses] })
+        list("links", cleaned)
+      end
+
+      # Parameters
+      # Name      Type    Description
+      # -------------------------------
+      # link_id  string  Id of the requested link
+      # -------------------------------
+      def get_link(link_id)
+        get("links/#{link_id}")
+      end
+
+      # Allowed attributes:
+      # Name          Type               Description
+      # ------------------------------------
+      # name          string (optional)  Name of the link. If none is specified, the external_url is used as a default
+      # external_url  string             Underlying identifying link/url of the link
+      # ------------------------------------
+      def create_link!(params = {})
+        cleaned = params.permit(:name, :external_url)
+        create("links", cleaned)
+      end
+
+      # Parameters
+      # Name      Type    Description
+      # -----------------------------
+      # link_id  string  Id of the requested link
+      # -----------------------------
+      #
+      # Allowed attributes:
+      # Name  Type    Description
+      # ------------------------------------
+      # name  string  New name of the link
+      # ------------------------------------
+      def update_link!(link_id, params = {})
+        cleaned = params.permit(:name)
+        update("links/#{link_id}", cleaned)
+      end
+
+      # Parameters
+      # Name      Type    Description
+      # -----------------------------
+      # link_id  string  Id of the requested link
+      # -----------------------------
+      #
+      # Allowed params:
+      # Name        Type               Description
+      # ------------------------------------------
+      # q           object (optional)  Search query.
+      # q.statuses  array (optional)   List of the statuses of the conversations you want to list
+      # ------------------------------------------
+      def get_link_conversations(link_id, params = {})
+        cleaned = params.permit({ q: [:statuses] })
+        list("links/#{link_id}/conversations", cleaned)
+      end
+    end
+  end
+end

--- a/lib/frontapp/client/topics.rb
+++ b/lib/frontapp/client/topics.rb
@@ -15,8 +15,9 @@ module Frontapp
       # q.statuses  array (optional)   List of the statuses of the conversations you want to list
       # ------------------------------------------
       def get_topic_conversations(topic_id, params = {})
-        cleaned = params.permit({ q: [:statuses] })
-        list("topics/#{topic_id}/conversations", cleaned)
+        warn "[DEPRECATION] `Topics` is deprecated.  Please use `Links` instead."
+
+        get_link_conversations(topic_id, params)
       end
     end
   end

--- a/spec/conversations_spec.rb
+++ b/spec/conversations_spec.rb
@@ -589,4 +589,34 @@ RSpec.describe 'Conversations' do
     frontapp.get_conversation_messages(conversation_id)
   end
 
+  it "can add conversation links by id" do
+    data = {
+      link_ids: ["top_55c8c149"]
+    }
+    stub_request(:post, "#{base_url}/conversations/#{conversation_id}/links").
+      with( headers: headers).
+      to_return(status: 202)
+    frontapp.add_conversation_links!(conversation_id, data)
+  end
+
+  it "can add conversation links by link external url" do
+    data = {
+      link_external_urls: ["example.com/my-link"]
+    }
+    stub_request(:post, "#{base_url}/conversations/#{conversation_id}/links").
+      with( headers: headers).
+      to_return(status: 202)
+    frontapp.add_conversation_links!(conversation_id, data)
+  end
+
+  it "can remove conversation links by id" do
+    data = {
+      link_ids: ["top_55c8c149"]
+    }
+    stub_request(:delete, "#{base_url}/conversations/#{conversation_id}/links").
+      with( headers: headers).
+      to_return(status: 204, body: nil)
+    frontapp.delete_tag!(conversation_id, data)
+  end
+
 end

--- a/spec/links_spec.rb
+++ b/spec/links_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'frontapp'
 
-RSpec.describe 'Topics' do
+RSpec.describe 'Links' do
 
   let(:headers) {
     {
@@ -10,13 +10,13 @@ RSpec.describe 'Topics' do
     }
   }
   let(:frontapp) { Frontapp::Client.new(auth_token: auth_token) }
-  let(:topic_id) { "top_55c8c149" }
-  let(:topic_conversations_response) {
+  let(:link_id) { "top_55c8c149" }
+  let(:link_conversations_response) {
     %Q{
 {
   "_pagination": {},
   "_links": {
-    "self": "https://api2.frontapp.com/topics/top_55c8c149/conversations"
+    "self": "https://api2.frontapp.com/links/top_55c8c149/conversations"
   },
   "_results": [
     {
@@ -136,11 +136,106 @@ RSpec.describe 'Topics' do
 }
     }
   }
+  let(:links_response) do
+    %Q{
+{
+  "_pagination": {
+    "next": null
+  },
+  "_links": {
+    "self": "https://api2.frontapp.com/links?"
+  },
+  "_results": [
+    {
+      "id": "top_55c8c149",
+      "name": "123456",
+      "type": "web",
+      "external_url": "https://example.com/something/123456",
+      "link": "https://example.com/something/123456"
+    },
+    {
+      "id": "top_55ih5t",
+      "name": "www.google.com",
+      "type": "web",
+      "external_url": "www.google.com",
+      "link": "www.google.com"
+    },
+    {
+      "id": "top_55i8f5",
+      "name": "something.io",
+      "type": "web",
+      "external_url": "http://something.io",
+      "link": "http://something.io"
+    }
+  ]
+}
+    }
+  end
+  let(:get_link_response) do
+    %Q{
+{
+  "_links"=>{"self"=>"https://lending-home.api.frontapp.com/links/top_55c8c149"},
+  "id": "top_55c8c149",
+  "name": "123456",
+  "type": "web",
+  "external_url": "https://example.com/something/123456",
+  "link": "https://example.com/something/123456"
+}
+    }
+  end
+  let(:create_link_response) {
+    %Q{
+{
+  "_links"=>{"self"=>"https://lending-home.api.frontapp.com/links/top_3ij8h"},
+  "id": "top_3ij8h",
+  "name": "Bla",
+  "type": "web",
+  "external_url": "bla.io",
+  "link": "bla.io"
+}
+    }
+  end
 
-  it "can get all topic conversations" do
-    stub_request(:get, "#{base_url}/topics/#{topic_id}/conversations").
+  it "can get all link conversations" do
+    stub_request(:get, "#{base_url}/links/#{link_id}/conversations").
       with( headers: headers).
-      to_return(status: 200, body: topic_conversations_response)
-    frontapp.get_topic_conversations(topic_id)
+      to_return(status: 200, body: link_conversations_response)
+    frontapp.get_link_conversations(link_id)
+  end
+
+  it "can list links" do
+    stub_request(:get, "#{base_url}/links").
+      with( headers: headers).
+      to_return(status: 200, body: links_response)
+    frontapp.links
+  end
+
+  it "can get a link" do
+    stub_request(:get, "#{base_url}/links/#{link_id}").
+      with( headers: headers).
+      to_return(status: 200, body: get_link_response)
+    frontapp.get_link(link_id)
+  end
+
+  it "can create a link" do
+    data = {
+      name: "New link",
+      external_url: "my.link"
+    }
+    stub_request(:post, "#{base_url}/links").
+      with( body: data.to_json,
+            headers: headers).
+      to_return(status: 200, body: )
+  end
+
+  it "can update a link name" do
+    data = {
+      name: "new name"
+    }
+    stub_request(:patch, "#{base_url}/links/#{link_id}").
+      with( body: data.to_json,
+            headers: headers).
+      to_return(status: 204)
+    frontapp.update_link!(link_id, data)
   end
 end


### PR DESCRIPTION
Topics is going to be deprecated and they released Links instead, so I am adding the new `links` endpoints as well putting a deprecated message on the old `topics`. 

Documentation: [FrontApp Links](https://dev.frontapp.com/reference/links)