### PR TITLE
Add api remove followers from a conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .rspec
 Gemfile.lock
 vendor
+.idea/
 
 # ignore RVM config
 .versions.conf

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ client.remove_conversation_links!("cnv_55c8c149", {
   link_ids: ["top_3ii5d", "top_3ih5t"]
 })
 
+# Add conversation followers
+client.add_conversation_followers!("cnv_55c8c149", {
+  teammate_ids: ["tea_64ue9", "tea_638yp"]
+})
+
 # Remove conversation followers
 client.remove_conversation_followers!("cnv_55c8c149", {
   teammate_ids: ["tea_64ue9", "tea_638yp"]

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ client.add_conversation_links!("cnv_55c8c149", {
 client.remove_conversation_links!("cnv_55c8c149", {
   link_ids: ["top_3ii5d", "top_3ih5t"]
 })
+
+# Remove conversation followers
+client.remove_conversation_followers!("cnv_55c8c149", {
+  teammate_ids: ["tea_64ue9", "tea_638yp"]
+})
 ```
 
 ### Events

--- a/lib/frontapp/client/conversations.rb
+++ b/lib/frontapp/client/conversations.rb
@@ -93,6 +93,17 @@ module Frontapp
         cleaned = params.permit(:link_ids)
         delete("conversations/#{conversation_id}/links", cleaned)
       end
+
+      # Parameters
+      # Name             Type              Description
+      # ----------------------------------------------
+      # conversation_id  string            The conversation Id
+      # teammate_ids     array of strings  follower IDs to remove
+      # ----------------------------------------------
+      def remove_conversation_followers!(conversation_id, params = {})
+        cleaned = params.permit(:teammate_ids)
+        delete("conversations/#{conversation_id}/followers", cleaned)
+      end
     end
   end
 end

--- a/lib/frontapp/client/conversations.rb
+++ b/lib/frontapp/client/conversations.rb
@@ -104,6 +104,17 @@ module Frontapp
         cleaned = params.permit(:teammate_ids)
         delete("conversations/#{conversation_id}/followers", cleaned)
       end
+
+      # Parameters
+      # Name             Type              Description
+      # ----------------------------------------------
+      # conversation_id  string            The conversation Id
+      # teammate_ids     array of strings  follower IDs to add
+      # ----------------------------------------------
+      def add_conversation_followers!(conversation_id, params = {})
+        cleaned = params.permit(:teammate_ids)
+        create_without_response("conversations/#{conversation_id}/followers", cleaned)
+      end
     end
   end
 end

--- a/spec/conversations_spec.rb
+++ b/spec/conversations_spec.rb
@@ -619,4 +619,13 @@ RSpec.describe 'Conversations' do
     frontapp.delete_tag!(conversation_id, data)
   end
 
+  it "can remove conversation followers by id" do
+    data = {
+      teammate_ids: ["tea_64ue9"]
+    }
+    stub_request(:delete, "#{base_url}/conversations/#{conversation_id}/followers").
+      with( headers: headers).
+      to_return(status: 204, body: nil)
+    frontapp.remove_conversation_followers!(conversation_id, data)
+  end
 end

--- a/spec/conversations_spec.rb
+++ b/spec/conversations_spec.rb
@@ -628,4 +628,14 @@ RSpec.describe 'Conversations' do
       to_return(status: 204, body: nil)
     frontapp.remove_conversation_followers!(conversation_id, data)
   end
+
+  it "can add conversation followers by id" do
+    data = {
+      link_ids: ["tea_64ue9"]
+    }
+    stub_request(:post, "#{base_url}/conversations/#{conversation_id}/followers").
+      with( headers: headers).
+      to_return(status: 202)
+    frontapp.add_conversation_followers!(conversation_id, data)
+  end
 end


### PR DESCRIPTION
Add a new option to delete followers of a conversation.

Documentation
https://dev.frontapp.com/reference/delete_conversations-conversation-id-followers

@scarhand @thechrisoshow could you review it, please?