### PR TITLE
Change URI.encode to URI.encode_www_form_component.

### DIFF
--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -136,15 +136,15 @@ module Frontapp
         res << q.map do |k, v|
           case v
           when Symbol, String
-            "q[#{k}]=#{URI.encode(v)}"
+            "q[#{k}]=#{URI.encode_www_form_component(v)}"
           when Array then
-            v.map { |c| "q[#{k}][]=#{URI.encode(c.to_s)}" }.join("&")
+            v.map { |c| "q[#{k}][]=#{URI.encode_www_form_component(c.to_s)}" }.join("&")
           else
-            "q[#{k}]=#{URI.encode(v.to_s)}"
+            "q[#{k}]=#{URI.encode_www_form_component(v.to_s)}"
           end
         end
       end
-      res << params.map {|k,v| "#{k}=#{URI.encode(v.to_s)}"}
+      res << params.map {|k,v| "#{k}=#{URI.encode_www_form_component(v.to_s)}"}
       res.join("&")
     end
 


### PR DESCRIPTION
This fixes a deprecation warning in Ruby 2.7 and NoMethodError in Ruby 3.

URI.encode has been deprecated/removed in Ruby versions > 2.7 and needs to be replaced with one of the other available methods.