### PR TITLE
Add gateway timeout error

### DIFF
--- a/lib/frontapp/error.rb
+++ b/lib/frontapp/error.rb
@@ -7,6 +7,7 @@ module Frontapp
         when 404 then NotFoundError
         when 409 then ConflictError
         when 429 then TooManyRequestsError
+        when 504 then GatewayTimeoutError
         else self
         end
       error_class.new(response)
@@ -23,4 +24,5 @@ module Frontapp
   class ConflictError < Error; end
   class UnauthorizedError < Error; end
   class TooManyRequestsError < Error; end
+  class GatewayTimeoutError < Error; end
 end


### PR DESCRIPTION
I was running into a gateway timeout, apparently on corrupted data. I added this error so I could more easily detect this problem and skip that batch rather than retry, which is appropriate for other errors such as TooManyRequestsError. 