### PR TITLE
Add a conversations/search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ note = client.add_contact_note!("ctc_55c8c149", {
 # Get all conversations
 conversations = client.conversations
 
+# Search conversations
+conversations = client.search_conversations("is:assigned before:1649974320")
+
 # Get a specific conversation
 converstation = client.get_conversation("cnv_55c8c149")
 

--- a/lib/frontapp/client/conversations.rb
+++ b/lib/frontapp/client/conversations.rb
@@ -6,6 +6,11 @@ module Frontapp
         list("conversations", params)
       end
 
+      def search_conversations(query, params = {})
+        encoded_query = URI.encode(query)
+        list("conversations/search/#{encoded_query}", params)
+      end
+
       # Parameters
       # Name             Type    Description
       # ------------------------------------

--- a/spec/conversations_spec.rb
+++ b/spec/conversations_spec.rb
@@ -540,6 +540,14 @@ RSpec.describe 'Conversations' do
     frontapp.conversations
   end
 
+  it "can search conversations" do
+    query = "is:assigned before:1649974320"
+    stub_request(:get, "#{base_url}/conversations/search/#{URI.encode(query)}").
+      with( headers: headers).
+      to_return(status: 200, body: all_conversations_response)
+    frontapp.search_conversations(query)
+  end
+
   it "can get a specific conversation" do
     stub_request(:get, "#{base_url}/conversations/#{conversation_id}").
       with( headers: headers).


### PR DESCRIPTION
This PR adds support for the `conversations/search/` endpoint as documented at https://dev.frontapp.com/reference/search-conversations

There's nothing wild here, the only caveat is that the search query needs to be URI encoded. This is taken care of in the added method.