### PR TITLE
Fix typo in test

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Client' do
       to_return(status: 200, body: JSON.generate(response_2))
     results = []
     frontapp.conversations do |conversations|
-      results.concat(converations)
+      results.concat(conversations)
     end
     expect(results).to eq([result_1, result_2])
   end


### PR DESCRIPTION
Before:

```
$ rspec                                                                                                                                                                                                            
.......F............................................................................

Failures:

  1) Client can list with a block
     Failure/Error: results.concat(converations)

     NameError:
       undefined local variable or method `converations' for #<RSpec::ExampleGroups::Client "can list with a block" (./spec/client_spec.rb:30)>
     # ./spec/client_spec.rb:39:in `block (3 levels) in <top (required)>'
     # ./lib/frontapp/client.rb:66:in `list'
     # ./lib/frontapp/client/conversations.rb:6:in `conversations'
     # ./spec/client_spec.rb:38:in `block (2 levels) in <top (required)>'
     # /Users/anthony/.rvm/gems/ruby-3.2.4/gems/webmock-3.25.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <top (required)>'

Finished in 0.04016 seconds (files took 0.39106 seconds to load)
84 examples, 1 failure

Failed examples:

rspec ./spec/client_spec.rb:30 # Client can list with a block
```

After:

```
$ rspec
....................................................................................

Finished in 0.03723 seconds (files took 0.13543 seconds to load)
84 examples, 0 failures
```