### PR TITLE
Add create draft reply

### DIFF
--- a/lib/frontapp/client.rb
+++ b/lib/frontapp/client.rb
@@ -7,6 +7,7 @@ require_relative 'client/comments.rb'
 require_relative 'client/contact_groups.rb'
 require_relative 'client/contacts.rb'
 require_relative 'client/conversations.rb'
+require_relative 'client/drafts.rb'
 require_relative 'client/events.rb'
 require_relative 'client/inboxes.rb'
 require_relative 'client/messages.rb'
@@ -29,6 +30,7 @@ module Frontapp
     include Frontapp::Client::ContactGroups
     include Frontapp::Client::Contacts
     include Frontapp::Client::Conversations
+    include Frontapp::Client::Drafts
     include Frontapp::Client::Events
     include Frontapp::Client::Inboxes
     include Frontapp::Client::Messages

--- a/lib/frontapp/client/drafts.rb
+++ b/lib/frontapp/client/drafts.rb
@@ -1,0 +1,28 @@
+module Frontapp
+  class Client
+    module Drafts
+      # See https://dev.frontapp.com/reference/create-draft-reply
+      def create_draft_reply(conversation_id, params)
+        # ordered in the same order as the API documentation
+        cleaned_params = params.permit(
+          :author_id,
+          :to,
+          :cc,
+          :bcc,
+          :subject,
+          :body,
+          :quote_body,
+          :attachments,
+          {
+            options: [:tags, :archive],
+          },
+          :mode,
+          :signature_id,
+          :should_add_default_signature,
+          :channel_id,
+        )
+        create("conversations/#{conversation_id}/drafts", cleaned_params)
+      end
+    end
+  end
+end

--- a/lib/frontapp/client/drafts.rb
+++ b/lib/frontapp/client/drafts.rb
@@ -13,9 +13,6 @@ module Frontapp
           :body,
           :quote_body,
           :attachments,
-          {
-            options: [:tags, :archive],
-          },
           :mode,
           :signature_id,
           :should_add_default_signature,

--- a/lib/frontapp/client/messages.rb
+++ b/lib/frontapp/client/messages.rb
@@ -10,7 +10,7 @@ module Frontapp
       def get_message(message_id)
         get("messages/#{message_id}")
       end
-      
+
       # Parameters
       # Name        Type    Description
       # -------------------------------
@@ -20,7 +20,7 @@ module Frontapp
         get_plain("messages/#{message_id}").b
         # .b sets encoding to ASCII-8BIT, which is safer for raw emails than UTF-8
       end
-      
+
       # Parameters
       # Name        Type    Description
       # -------------------------------

--- a/spec/drafts_spec.rb
+++ b/spec/drafts_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+require 'frontapp'
+
+RSpec.describe 'Drafts' do
+  let(:frontapp) { Frontapp::Client.new(auth_token: auth_token) }
+  let(:conversation_id) { 'cnv_55c8c149' }
+
+  # see https://dev.frontapp.com/reference/drafts
+  let(:create_draft_reply_response) do
+    %Q{
+{
+  "_links": {
+    "self": "https://api2.frontapp.com/messages/msg_55c8c149",
+    "related": {
+      "conversation": "https://api2.frontapp.com/conversations/cnv_55c8c149",
+      "message_replied_to": "https://api2.frontapp.com/messages/msg_1ab23cd4"
+    }
+  },
+  "id": "msg_55c8c149",
+  "type": "email",
+  "is_inbound": true,
+  "is_draft": false,
+  "created_at": 1453770984.123,
+  "blurb": "Anything less than immortality is a...",
+  "author": {
+    "_links": {
+      "self": "https://api2.frontapp.com/teammates/tea_55c8c149",
+      "related": {
+        "inboxes": "https://api2.frontapp.com/teammates/tea_55c8c149/inboxes",
+        "conversations": "https://api2.frontapp.com/teammates/tea_55c8c149/conversations"
+      }
+    },
+    "id": "tea_55c8c149",
+    "email": "leela@planet-express.com",
+    "username": "leela",
+    "first_name": "Leela",
+    "last_name": "Turanga",
+    "is_admin": true,
+    "is_available": true,
+    "is_blocked": false
+  },
+  "recipients": [
+    {
+      "_links": {
+        "related": {
+          "contact": "https://api2.frontapp.com/contacts/crd_55c8c149"
+        }
+      },
+      "handle": "calculon@momsbot.com",
+      "role": "to"
+    }
+  ],
+  "body": "Anything less than immortality is a complete waste of time.",
+  "text": "Anything less than immortality is a complete waste of time.",
+  "attachments": [
+    {
+      "filename": "attachment.jpg",
+      "url": "https://api2.frontapp.com/download/fil_55c8c149",
+      "content_type": "image/jpeg",
+      "size": 10000,
+      "metadata": {
+        "is_inline": true,
+        "cid": "123456789"
+      }
+    }
+  ],
+  "metadata": {}
+}
+    }
+  end
+
+  describe '#create_draft_reply' do
+    it 'creates a draft valid' do
+      body = {
+        author_id: 'alt:email:leela@planet-exress.com',
+        body: 'Why is Zoidberg the only one still alone?',
+        to: ['calculon@momsbot.com'],
+      }
+
+      stub_request(:post, "#{base_url}/conversations/#{conversation_id}/drafts")
+        .with(body: body, headers: standard_headers)
+        .to_return(status: 200, body: create_draft_reply_response)
+
+      response = frontapp.create_draft_reply(conversation_id, body)
+
+      expect(response).to eq(JSON.parse(create_draft_reply_response))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,3 +111,10 @@ end
 def auth_token
   ""
 end
+
+def standard_headers
+  {
+    "Accept" => "application/json",
+    "Authorization" => "Bearer #{auth_token}",
+  }
+end


### PR DESCRIPTION
Hi, hope you're doing well. Thanks for merging the test fix PR (#30) quickly yesterday!

I was in the tests since I wanted to add a new endpoint that we want to use on our project. I tried to follow the conventions of the project as best as I could for implementing it and adding tests.

Implements https://dev.frontapp.com/reference/create-draft-reply since that is currently the only drafts endpoint that we need for our project.

Open question: I didn't add a

```
      # Parameters
      # Name        Type    Description
      # ------------------------------------
      # ...
```
etc. block. Do you use this to generate documentation, etc.? If so, I can add it in. However, it seems like it roughly follows the Front API docs, so it might be helpful to point folks to that instead?

Thanks!